### PR TITLE
斗胆微调了一个小问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tomcat",
   "displayName": "Tomcat",
   "description": "Fully Automated Support for Apache Tomcat",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "publisher": "Al-rimi",
   "author": {
     "email": "abdullah@syalux.com",

--- a/src/services/Builder.ts
+++ b/src/services/Builder.ts
@@ -187,7 +187,7 @@ export class Builder {
             }
 
             // Register a keyword callback in the Logger
-            logger.onKeyword('Server startup in milliseconds', () => {
+            logger.onKeyword('毫秒后服务器启动', () => {
                 Browser.getInstance().run(appName); // Start the browser
             });
 

--- a/src/services/Builder.ts
+++ b/src/services/Builder.ts
@@ -186,6 +186,11 @@ export class Builder {
                 await action();
             }
 
+            // Register a keyword callback in the Logger
+            logger.onKeyword('Server startup in milliseconds', () => {
+                Browser.getInstance().run(appName); // Start the browser
+            });
+
             logger.defaultStatusBar();
 
             const endTime = performance.now();
@@ -196,7 +201,6 @@ export class Builder {
                 await new Promise(resolve => setTimeout(resolve, 50));
                 await tomcat.reload();
                 await new Promise(resolve => setTimeout(resolve, 100));
-                Browser.getInstance().run(appName);
             }
 
             this.attempts = 0;

--- a/src/services/Logger.ts
+++ b/src/services/Logger.ts
@@ -664,18 +664,24 @@ export class Logger {
         return dateMatch ? Date.parse(dateMatch[1]) : 0;
     }
 
+    private keywordCallbacks: { keyword: string, callback: () => void }[] = [];
+
     /**
-     * Core logging mechanism
+     * Register a callback for detecting a specific keyword in logs.
      * 
-     * Handles log message processing with:
-     * - Level filtering
-     * - Timestamping
-     * - Formatting
-     * - Multi-channel routing
+     * @param keyword The keyword to detect.
+     * @param callback The callback to execute when the keyword is detected.
+     */
+    public onKeyword(keyword: string, callback: () => void): void {
+        this.keywordCallbacks.push({ keyword, callback });
+    }
+
+    /**
+     * Core logging mechanism (modified).
      * 
-     * @param level Log severity level
-     * @param message Log content
-     * @param showUI Optional UI notification callback
+     * @param level The log severity level.
+     * @param message The content of the log.
+     * @param showUI Optional callback to show a UI notification.
      */
     private log(
         level: string,
@@ -689,7 +695,13 @@ export class Logger {
         const timestamp = this.showTimestamp ? `[${new Date().toLocaleString()}] ` : '';
         const formattedMessage = `${timestamp}[${level}] ${message}`;
 
-        // Directly append to channel without recursion
+        // Detect the keyword and trigger the callback
+        for (const { keyword, callback } of this.keywordCallbacks) {
+            if (message.includes(keyword)) {
+                callback(); // Trigger the callback
+            }
+        }
+
         this.outputChannel.appendLine(formattedMessage);
 
         if (showUI) {


### PR DESCRIPTION
##  实现延迟启动浏览器

原先版本中，插件会在maven编译完成后便启动浏览器，未顾及tomcat是否启动成功
当tomcat启动较慢时，可能会出现网页已打开但服务未启动导致的无法访问
故在代码中增添等待tomcat启动功能，当前实现方案为log关键词检测，存在一定局限性，无法通用，仅给大佬提个建议

> TODO: 实现通用检测tomcat启动状态